### PR TITLE
apply python requirements >=3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"
@@ -157,7 +156,6 @@ test_and_publish:
           matrix:
             parameters:
               version:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_requirements = ['pytest>=3', ]
 setup(
     author="The pyfar developers",
     author_email='info@pyfar.org',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Scientists',
@@ -28,7 +28,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
     ],
-    description="A python package for mmaterial  modeling and quantification in acoustics.",
+    description="A python package for material modeling and quantification in acoustics.",
     install_requires=requirements,
     license="MIT license",
     long_description=readme + '\n\n' + history,


### PR DESCRIPTION
we just support python 3.8+ but tests are still running for 3.7. See #8