### PR TITLE
Feature: correlation method after mommertz

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -16,7 +16,7 @@ Modules
 .. toctree::
    :maxdepth: 1
 
-   modules/imkar
+   modules/imkar.scattering.freefield
 
 
 .. _examples gallery: https://pyfar-gallery.readthedocs.io/en/latest/examples_gallery.html

--- a/docs/modules/imkar.rst
+++ b/docs/modules/imkar.rst
@@ -1,7 +1,0 @@
-imkar
-=====
-
-.. automodule:: imkar
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/modules/imkar.scattering.freefield.rst
+++ b/docs/modules/imkar.scattering.freefield.rst
@@ -1,0 +1,7 @@
+imkar.scattering.freefield
+==========================
+
+.. automodule:: imkar.scattering.freefield
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/imkar/__init__.py
+++ b/imkar/__init__.py
@@ -5,3 +5,10 @@
 __author__ = """The pyfar developers"""
 __email__ = ''
 __version__ = '0.1.0'
+
+
+from . import scattering
+
+__all__ = [
+    "scattering",
+]

--- a/imkar/scattering/__init__.py
+++ b/imkar/scattering/__init__.py
@@ -1,0 +1,7 @@
+"""Imkar scattering module."""
+
+from . import freefield
+
+__all__ = [
+    "freefield",
+]

--- a/imkar/scattering/freefield.py
+++ b/imkar/scattering/freefield.py
@@ -49,10 +49,9 @@ def correlation_method(
     Returns
     -------
     scattering_coefficients : :py:class:`~pyfar.classes.audio.FrequencyData`
-        The scattering coefficient of the broadcasted shape of
-        ``sample_pressure`` and ``reference_pressure`` excluding the
+        The scattering coefficient of the broadcasted cshape of
+        ``sample_pressure`` and ``reference_pressure``, excluding the
         last dimension.
-        of frequency.
 
     References
     ----------

--- a/imkar/scattering/freefield.py
+++ b/imkar/scattering/freefield.py
@@ -61,7 +61,7 @@ def correlation_method(
             Acoustics, vol. 60, no. 2, pp. 201-203, June 2000,
             doi: 10.1016/S0003-682X(99)00057-2.
 
-    """
+    """  # noqa: E501
     # check input types
     if not isinstance(sample_pressure, (pf.FrequencyData, pf.Signal)):
         raise TypeError(

--- a/imkar/scattering/freefield.py
+++ b/imkar/scattering/freefield.py
@@ -87,7 +87,8 @@ def correlation_method(
             "broadcastable except for the last dimension")
     # Test whether the objects are able to perform arithmetic operations.
     # e.g. does the frequency vectors match
-    _ = sample_pressure + p_reference
+    _ = sample_pressure + reference_pressure
+
     # prepare data
     microphone_weights = microphone_weights[:, np.newaxis]
     p_sample = sample_pressure.freq

--- a/imkar/scattering/freefield.py
+++ b/imkar/scattering/freefield.py
@@ -31,12 +31,12 @@ def correlation_method(
 
     Parameters
     ----------
-    sample_pressure : :py:class:`~pyfar.FrequencyData`, :py:class:`~pyfar.Signal`
+    sample_pressure : pyfar.FrequencyData, pyfar.Signal
         Reflected sound pressure or directivity of the test sample. Its cshape
         must be (..., microphone_weights.size) and broadcastable to the
         cshape of ``reference_pressure``. The frequency vectors of both
         ``sample_pressure`` and ``reference_pressure`` must match.
-    reference_pressure : :py:class:`~pyfar.FrequencyData`, :py:class:`~pyfar.Signal`
+    reference_pressure : pyfar.FrequencyData, pyfar.Signal
         Reflected sound pressure or directivity of the reference sample. Its
         cshape must be (..., microphone_weights.size) and broadcastable to the
         cshape of ``sample_pressure``. The frequency vectors of both
@@ -48,7 +48,7 @@ def correlation_method(
 
     Returns
     -------
-    scattering_coefficients : :py:class:`~pyfar.classes.audio.FrequencyData`
+    scattering_coefficients : pyfar.FrequencyData
         The scattering coefficient of the broadcasted cshape of
         ``sample_pressure`` and ``reference_pressure``, excluding the
         last dimension.
@@ -60,7 +60,7 @@ def correlation_method(
             Acoustics, vol. 60, no. 2, pp. 201-203, June 2000,
             doi: 10.1016/S0003-682X(99)00057-2.
 
-    """  # noqa: E501
+    """
     # check input types
     if not isinstance(sample_pressure, (pf.FrequencyData, pf.Signal)):
         raise TypeError(

--- a/imkar/scattering/freefield.py
+++ b/imkar/scattering/freefield.py
@@ -85,7 +85,9 @@ def correlation_method(
         raise ValueError(
             "The cshape of sample_pressure and reference_pressure must be "
             "broadcastable except for the last dimension")
-
+    # Test whether the objects are able to perform arithmetic operations.
+    # e.g. does the frequency vectors match
+    _ = sample_pressure + p_reference
     # prepare data
     microphone_weights = microphone_weights[:, np.newaxis]
     p_sample = sample_pressure.freq

--- a/imkar/scattering/freefield.py
+++ b/imkar/scattering/freefield.py
@@ -1,0 +1,108 @@
+"""Scattering calculation functions based on free-field data."""
+import numpy as np
+import pyfar as pf
+
+
+def correlation_method(
+        sample_pressure, reference_pressure, microphone_weights):
+    r"""
+    Calculate the incident-dependent free-field scattering coefficient.
+
+    This function uses the Mommertz correlation method [#]_ to compute the
+    scattering coefficient of the input data:
+
+    .. math::
+        s = 1 -
+            \frac{|\sum_w \underline{p}_{\text{sample}}(\vartheta,\varphi)
+            \cdot \underline{p}_{\text{reference}}^*(\vartheta,\varphi)
+            \cdot w(\vartheta,\varphi)|^2}
+            {\sum_w |\underline{p}_{\text{sample}}(\vartheta,\varphi)|^2
+            \cdot w(\vartheta,\varphi) \cdot \sum_w
+            |\underline{p}_{\text{reference}}(\vartheta,\varphi)|^2
+            \cdot w(\vartheta,\varphi) }
+
+    where:
+        - :math:`\underline{p}_{\text{sample}}` is the reflected sound
+          pressure of the sample under investigation.
+        - :math:`\underline{p}_{\text{reference}}` is the reflected sound
+          pressure from the reference sample.
+        - :math:`w` represents the area weights of the sampling, and
+          :math:`\vartheta` and :math:`\varphi` are the ``colatitude``
+          and ``azimuth`` angles from the
+          :py:class:`~pyfar.classes.coordinates.Coordinates` object.
+
+    The test sample is assumed to lie in the x-y-plane.
+
+    Parameters
+    ----------
+    sample_pressure : :py:class:`~pyfar.classes.audio.FrequencyData`
+        Reflected sound pressure or directivity of the test sample. Its cshape
+        must be (..., microphone_weights.size) and broadcastable to the
+        cshape of ``reference_pressure``.
+    reference_pressure : :py:class:`~pyfar.classes.audio.FrequencyData`
+        Reflected sound pressure or directivity of the reference sample. Its
+        cshape must be (..., microphone_weights.size) and broadcastable to the
+        cshape of ``sample_pressure``.
+    microphone_weights : array_like
+        1D array containing the area weights for the microphone positions.
+        No normalization is required. Its shape must match the last dimension
+        in the cshape of ``sample_pressure`` and ``reference_pressure``.
+
+    Returns
+    -------
+    scattering_coefficients : :py:class:`~pyfar.classes.audio.FrequencyData`
+        The scattering coefficient for each incident direction as a function
+        of frequency.
+
+    References
+    ----------
+    .. [#]  E. Mommertz, "Determination of scattering coefficients from the
+            reflection directivity of architectural surfaces," Applied
+            Acoustics, vol. 60, no. 2, pp. 201-203, June 2000,
+            doi: 10.1016/S0003-682X(99)00057-2.
+
+    """
+    # check input types
+    if not isinstance(sample_pressure, pf.FrequencyData):
+        raise TypeError("sample_pressure must be of type pyfar.FrequencyData")
+    if not isinstance(reference_pressure, pf.FrequencyData):
+        raise TypeError(
+            "reference_pressure must be of type pyfar.FrequencyData")
+    microphone_weights = np.atleast_1d(
+        np.asarray(microphone_weights, dtype=float))
+
+    # check input dimensions
+    if sample_pressure.cshape[-1] != microphone_weights.size:
+        raise ValueError(
+            "The last dimension of sample_pressure must match the size of "
+            "microphone_weights")
+    if reference_pressure.cshape[-1] != microphone_weights.size:
+        raise ValueError(
+            "The last dimension of reference_pressure must match the size of "
+            "microphone_weights")
+
+    if sample_pressure.cshape[:-1] != reference_pressure.cshape[:-1]:
+        raise ValueError(
+            "The cshape of sample_pressure and reference_pressure must be "
+            "broadcastable except for the last dimension")
+
+    # prepare data
+    microphone_weights = microphone_weights[:, np.newaxis]
+    p_sample = sample_pressure.freq
+    p_reference = reference_pressure.freq
+
+    # calculate according to mommertz correlation method Equation (5)
+    p_sample_sum = np.sum(microphone_weights * np.abs(p_sample)**2, axis=-2)
+    p_ref_sum = np.sum(microphone_weights * np.abs(p_reference)**2, axis=-2)
+    p_cross_sum = np.sum(
+            p_sample * np.conj(p_reference) * microphone_weights, axis=-2)
+
+    data_scattering_coefficient \
+        = 1 - ((np.abs(p_cross_sum)**2)/(p_sample_sum*p_ref_sum))
+
+    # create pyfar.FrequencyData object
+    scattering_coefficients = pf.FrequencyData(
+        data_scattering_coefficient,
+        sample_pressure.frequencies)
+
+    return scattering_coefficients

--- a/imkar/scattering/freefield.py
+++ b/imkar/scattering/freefield.py
@@ -32,14 +32,14 @@ def correlation_method(
     Parameters
     ----------
     sample_pressure : pyfar.FrequencyData, pyfar.Signal
-        Reflected sound pressure or directivity of the test sample. Its `cshape`
-        must be ``(..., microphone_weights.size)`` and broadcastable to the
-        `cshape` of ``reference_pressure``. The frequency vectors of both
-        ``sample_pressure`` and ``reference_pressure`` must match.
+        Reflected sound pressure or directivity of the test sample. Its
+        `cshape` must be ``(..., microphone_weights.size)`` and broadcastable
+        to the `cshape` of ``reference_pressure``. The frequency vectors
+        of both ``sample_pressure`` and ``reference_pressure`` must match.
     reference_pressure : pyfar.FrequencyData, pyfar.Signal
         Reflected sound pressure or directivity of the reference sample. Its
-        `cshape` must be (..., microphone_weights.size) and broadcastable to the
-        `cshape` of ``sample_pressure``. The frequency vectors of both
+        `cshape` must be (..., microphone_weights.size) and broadcastable
+        to the `cshape` of ``sample_pressure``. The frequency vectors of both
         ``sample_pressure`` and ``reference_pressure`` must match.
     microphone_weights : array_like
         1D array containing the area weights for the microphone positions.
@@ -82,10 +82,11 @@ def correlation_method(
         raise ValueError(
             "The last dimension of reference_pressure must match the size of "
             "microphone_weights")
-
-    # Test whether the objects are able to perform arithmetic operations.
-    # e.g. does the frequency vectors match
-    _ = sample_pressure + reference_pressure
+    # check frequency vectors
+    if not np.allclose(
+            reference_pressure.frequencies, sample_pressure.frequencies,
+            atol=1e-15):
+        raise ValueError("The frequencies do not match.")
 
     # prepare data
     microphone_weights = microphone_weights[:, np.newaxis]

--- a/imkar/scattering/freefield.py
+++ b/imkar/scattering/freefield.py
@@ -27,29 +27,29 @@ def correlation_method(
         - :math:`\underline{p}_{\text{reference}}` is the reflected sound
           pressure from the reference sample.
         - :math:`\Omega_r` represents the solid angle of the microphone
-          positions and :math:`w(\Omega_r)` represents its area weights.
+          positions and :math:`w(\Omega_r)` represents its area weight.
 
     Parameters
     ----------
     sample_pressure : pyfar.FrequencyData, pyfar.Signal
-        Reflected sound pressure or directivity of the test sample. Its cshape
-        must be (..., microphone_weights.size) and broadcastable to the
-        cshape of ``reference_pressure``. The frequency vectors of both
+        Reflected sound pressure or directivity of the test sample. Its `cshape`
+        must be ``(..., microphone_weights.size)`` and broadcastable to the
+        `cshape` of ``reference_pressure``. The frequency vectors of both
         ``sample_pressure`` and ``reference_pressure`` must match.
     reference_pressure : pyfar.FrequencyData, pyfar.Signal
         Reflected sound pressure or directivity of the reference sample. Its
-        cshape must be (..., microphone_weights.size) and broadcastable to the
-        cshape of ``sample_pressure``. The frequency vectors of both
+        `cshape` must be (..., microphone_weights.size) and broadcastable to the
+        `cshape` of ``sample_pressure``. The frequency vectors of both
         ``sample_pressure`` and ``reference_pressure`` must match.
     microphone_weights : array_like
         1D array containing the area weights for the microphone positions.
         No normalization is required. Its shape must match the last dimension
-        in the cshape of ``sample_pressure`` and ``reference_pressure``.
+        in the `cshape` of ``sample_pressure`` and ``reference_pressure``.
 
     Returns
     -------
     scattering_coefficients : pyfar.FrequencyData
-        The scattering coefficient of the broadcasted cshape of
+        The scattering coefficient of the broadcasted `cshape` of
         ``sample_pressure`` and ``reference_pressure``, excluding the
         last dimension.
 

--- a/tests/test_scattering_freefield.py
+++ b/tests/test_scattering_freefield.py
@@ -144,9 +144,9 @@ def test_correlation_method_invalid_reference_pressure_type():
 
 
 def test_correlation_method_mismatched_sample_pressure_weights():
-    sample_pressure = pf.FrequencyData(np.array([[1, 2, 3]]), [100, 200, 300])
+    sample_pressure = pf.FrequencyData(np.array([[1, 2, 3]]).T, [100])
     reference_pressure = pf.FrequencyData(
-        np.array([[1, 2, 3]]), [100, 200, 300])
+        np.array([[1, 2]]).T, [100])
     microphone_weights = np.array([0.5, 0.5])
     with pytest.raises(
             ValueError, match="The last dimension of sample_pressure must "
@@ -156,23 +156,12 @@ def test_correlation_method_mismatched_sample_pressure_weights():
 
 
 def test_correlation_method_mismatched_reference_pressure_weights():
-    sample_pressure = pf.FrequencyData(np.array([[1, 2, 3]]), [100, 200, 300])
+    sample_pressure = pf.FrequencyData(np.array([[1, 2]]).T, [100])
     reference_pressure = pf.FrequencyData(
-        np.array([[1, 2, 3]]), [100, 200, 300])
+        np.array([[1, 2, 3]]).T, [100])
     microphone_weights = np.array([0.5, 0.5])
     with pytest.raises(
-            ValueError, match="The last dimension of sample_pressure must "
-            "match the size of microphone_weights"):
-        sff.correlation_method(
-            sample_pressure, reference_pressure, microphone_weights)
-
-
-def test_correlation_method_mismatched_sample_reference_shapes():
-    sample_pressure = pf.FrequencyData(np.array([[1, 2, 3]]), [100, 200, 300])
-    reference_pressure = pf.FrequencyData(np.array([[1, 2]]), [100, 200])
-    microphone_weights = np.array([0.5, 0.5, 0.5])
-    with pytest.raises(
-            ValueError, match="The last dimension of sample_pressure must "
+            ValueError, match="The last dimension of reference_pressure must "
             "match the size of microphone_weights"):
         sff.correlation_method(
             sample_pressure, reference_pressure, microphone_weights)

--- a/tests/test_scattering_freefield.py
+++ b/tests/test_scattering_freefield.py
@@ -6,6 +6,26 @@ from imkar.scattering import freefield as sff
 
 
 def plane_wave(amplitude, direction, sampling):
+    """Generate a plane wave for a given direction and sampling.
+
+    This function is just used for testing purposes, so the frequency is
+    fixed to 5000 Hz.
+
+    Parameters
+    ----------
+    amplitude : float
+        The amplitude of the plane wave.
+    direction : pf.Coordinates
+        The direction of the plane wave.
+    sampling : pf.Sampling
+        The sampling grid for the plane wave.
+
+    Returns
+    -------
+    pf.FrequencyData
+        The generated plane wave in the frequency domain.
+    """
+
     f = 5000
     c = 343
     x = sampling
@@ -19,7 +39,7 @@ def plane_wave(amplitude, direction, sampling):
     )
 
 
-def test_correlation_method_0():
+def test_correlation_zero_scattering():
     sampling = pf.samplings.sph_equal_area(5000)
     sampling.weights = pf.samplings.calculate_sph_voronoi_weights(sampling)
     sampling = sampling[sampling.z>0]
@@ -33,12 +53,23 @@ def test_correlation_method_0():
 
 @pytest.mark.parametrize("s_scatter", [0.1, 0.5, 0.9])
 @pytest.mark.parametrize("Phi_scatter_deg", [30, 60, 90, 120, 150, 42])
-def test_correlation_method_with_plane_waves(s_scatter, Phi_scatter_deg):
+def test_correlation_fractional_scattering(s_scatter, Phi_scatter_deg):
+    """
+    Test analytic scattering coefficient calculation for non 0 or 1.
+
+    for the sample pressure, two plane waves are used. The scattered and the
+    specular wave. The reflection factor of both waves is calculated based on
+    the scattering coefficient and the scattering angle.
+    """
+    # calculate the specular and scattered reflection factors
     s_spec = 1-s_scatter
     Phi_spec = 45/180*np.pi
     Phi_scatter = Phi_scatter_deg/180*np.pi
     R_spec = np.sqrt(s_spec)
     R_scatter = np.sqrt(np.abs(s_scatter*np.sin(Phi_spec)/np.sin(Phi_scatter)))
+
+    # define the sampling grid and generate the plane waves
+    # for the sample pressure and the reference pressure
     sampling = pf.samplings.sph_equal_area(10000)
     sampling.weights = pf.samplings.calculate_sph_voronoi_weights(sampling)
     sampling = sampling[sampling.z>0]
@@ -48,20 +79,29 @@ def test_correlation_method_with_plane_waves(s_scatter, Phi_scatter_deg):
     sample_pressure += plane_wave(
         R_scatter,
         pf.Coordinates.from_spherical_front(np.pi/2, Phi_scatter, 1), sampling)
+
+    # Calculate the scattering coefficient with for the specular wave
+    # in other words, the reference pressure is the specular wave (R=1)
     reference_pressure = plane_wave(
         1, pf.Coordinates.from_spherical_front(np.pi/2, Phi_spec, 1), sampling)
     sd_spec = 1-sff.correlation_method(
         sample_pressure, reference_pressure, sampling.weights,
     )
+    npt.assert_almost_equal(sd_spec.freq, s_spec, 1)
+
+    # Calculate the scattering coefficient with for the scattered wave
+    # in other words, the reference pressure is the scattered wave (R=1)
+    # to the result will be 1-s_scatter
     reference_pressure = plane_wave(
         1, pf.Coordinates.from_spherical_front(
             np.pi/2, Phi_scatter, 1), sampling)
     sd_scatter = 1-sff.correlation_method(
         sample_pressure, reference_pressure, sampling.weights,
     )
-    npt.assert_almost_equal(sd_spec.freq, s_spec, 1)
     npt.assert_almost_equal(sd_scatter.freq, s_scatter, 1)
 
+    # Calculate the scattering coefficient with for 5° more then the specular
+    # wave, than the scattering coefficient should be 0
     reference_pressure = plane_wave(
         1, pf.Coordinates.from_spherical_front(
             np.pi/2, Phi_spec+5/180*np.pi, 1), sampling)
@@ -71,16 +111,16 @@ def test_correlation_method_with_plane_waves(s_scatter, Phi_scatter_deg):
     npt.assert_almost_equal(sd_scatter_0.freq, 0, 1)
 
 
-def test_correlation_method():
+def test_correlation_one_scattering():
     sampling = pf.samplings.sph_equal_area(5000)
     sampling.weights = pf.samplings.calculate_sph_voronoi_weights(sampling)
     sampling = sampling[sampling.z>0]
-    sample_pressure = plane_wave(1, pf.Coordinates(0, 0, 1), sampling)
+    sample_pressure = plane_wave(1, pf.Coordinates(0, 1, 0), sampling)
     reference_pressure = plane_wave(1, pf.Coordinates(0, 0, 1), sampling)
     s = sff.correlation_method(
         sample_pressure, reference_pressure, sampling.weights,
     )
-    npt.assert_almost_equal(s.freq, 0)
+    npt.assert_almost_equal(s.freq, 1, decimal=3)
 
 
 def test_correlation_method_invalid_sample_pressure_type():

--- a/tests/test_scattering_freefield.py
+++ b/tests/test_scattering_freefield.py
@@ -1,0 +1,138 @@
+import pyfar as pf
+import numpy as np
+import numpy.testing as npt
+import pytest
+from imkar.scattering import freefield as sff
+
+
+def plane_wave(amplitude, direction, sampling):
+    f = 5000
+    c = 343
+    x = sampling
+    direction.cartesian = direction.cartesian/direction.radius
+    dot_product = direction.x*x.x+direction.y*x.y+direction.z*x.z
+    dot_product = dot_product[..., np.newaxis]
+    f = np.atleast_1d(f)
+    return pf.FrequencyData(
+        amplitude*np.exp(-1j*2*np.pi*f/c*dot_product),
+        frequencies=f,
+    )
+
+
+def test_correlation_method_0():
+    sampling = pf.samplings.sph_equal_area(5000)
+    sampling.weights = pf.samplings.calculate_sph_voronoi_weights(sampling)
+    sampling = sampling[sampling.z>0]
+    sample_pressure = plane_wave(1, pf.Coordinates(0, 0, 1), sampling)
+    reference_pressure = plane_wave(1, pf.Coordinates(0, 0, 1), sampling)
+    s = sff.correlation_method(
+        sample_pressure, reference_pressure, sampling.weights,
+    )
+    npt.assert_almost_equal(s.freq, 0)
+
+
+@pytest.mark.parametrize("s_scatter", [0.1, 0.5, 0.9])
+@pytest.mark.parametrize("Phi_scatter_deg", [30, 60, 90, 120, 150, 42])
+def test_correlation_method_with_plane_waves(s_scatter, Phi_scatter_deg):
+    s_spec = 1-s_scatter
+    Phi_spec = 45/180*np.pi
+    Phi_scatter = Phi_scatter_deg/180*np.pi
+    R_spec = np.sqrt(s_spec)
+    R_scatter = np.sqrt(np.abs(s_scatter*np.sin(Phi_spec)/np.sin(Phi_scatter)))
+    sampling = pf.samplings.sph_equal_area(10000)
+    sampling.weights = pf.samplings.calculate_sph_voronoi_weights(sampling)
+    sampling = sampling[sampling.z>0]
+    sample_pressure = plane_wave(
+        R_spec,
+        pf.Coordinates.from_spherical_front(np.pi/2, Phi_spec, 1), sampling)
+    sample_pressure += plane_wave(
+        R_scatter,
+        pf.Coordinates.from_spherical_front(np.pi/2, Phi_scatter, 1), sampling)
+    reference_pressure = plane_wave(
+        1, pf.Coordinates.from_spherical_front(np.pi/2, Phi_spec, 1), sampling)
+    sd_spec = 1-sff.correlation_method(
+        sample_pressure, reference_pressure, sampling.weights,
+    )
+    reference_pressure = plane_wave(
+        1, pf.Coordinates.from_spherical_front(
+            np.pi/2, Phi_scatter, 1), sampling)
+    sd_scatter = 1-sff.correlation_method(
+        sample_pressure, reference_pressure, sampling.weights,
+    )
+    npt.assert_almost_equal(sd_spec.freq, s_spec, 1)
+    npt.assert_almost_equal(sd_scatter.freq, s_scatter, 1)
+
+    reference_pressure = plane_wave(
+        1, pf.Coordinates.from_spherical_front(
+            np.pi/2, Phi_spec+5/180*np.pi, 1), sampling)
+    sd_scatter_0 = 1-sff.correlation_method(
+        sample_pressure, reference_pressure, sampling.weights,
+    )
+    npt.assert_almost_equal(sd_scatter_0.freq, 0, 1)
+
+
+def test_correlation_method():
+    sampling = pf.samplings.sph_equal_area(5000)
+    sampling.weights = pf.samplings.calculate_sph_voronoi_weights(sampling)
+    sampling = sampling[sampling.z>0]
+    sample_pressure = plane_wave(1, pf.Coordinates(0, 0, 1), sampling)
+    reference_pressure = plane_wave(1, pf.Coordinates(0, 0, 1), sampling)
+    s = sff.correlation_method(
+        sample_pressure, reference_pressure, sampling.weights,
+    )
+    npt.assert_almost_equal(s.freq, 0)
+
+
+def test_correlation_method_invalid_sample_pressure_type():
+    reference_pressure = pf.FrequencyData(np.array([1, 2, 3]), [100, 200, 300])
+    microphone_weights = np.array([0.5, 0.5, 0.5])
+    with pytest.raises(
+            TypeError, match="sample_pressure must be of type "
+            "pyfar.FrequencyData"):
+        sff.correlation_method(
+            "invalid_type", reference_pressure, microphone_weights)
+
+
+def test_correlation_method_invalid_reference_pressure_type():
+    sample_pressure = pf.FrequencyData(np.array([1, 2, 3]), [100, 200, 300])
+    microphone_weights = np.array([0.5, 0.5, 0.5])
+    with pytest.raises(
+            TypeError, match="reference_pressure must be of type "
+            "pyfar.FrequencyData"):
+        sff.correlation_method(
+            sample_pressure, "invalid_type", microphone_weights)
+
+
+def test_correlation_method_mismatched_sample_pressure_weights():
+    sample_pressure = pf.FrequencyData(np.array([[1, 2, 3]]), [100, 200, 300])
+    reference_pressure = pf.FrequencyData(
+        np.array([[1, 2, 3]]), [100, 200, 300])
+    microphone_weights = np.array([0.5, 0.5])
+    with pytest.raises(
+            ValueError, match="The last dimension of sample_pressure must "
+            "match the size of microphone_weights"):
+        sff.correlation_method(
+            sample_pressure, reference_pressure, microphone_weights)
+
+
+def test_correlation_method_mismatched_reference_pressure_weights():
+    sample_pressure = pf.FrequencyData(np.array([[1, 2, 3]]), [100, 200, 300])
+    reference_pressure = pf.FrequencyData(
+        np.array([[1, 2, 3]]), [100, 200, 300])
+    microphone_weights = np.array([0.5, 0.5])
+    with pytest.raises(
+            ValueError, match="The last dimension of sample_pressure must "
+            "match the size of microphone_weights"):
+        sff.correlation_method(
+            sample_pressure, reference_pressure, microphone_weights)
+
+
+def test_correlation_method_mismatched_sample_reference_shapes():
+    sample_pressure = pf.FrequencyData(np.array([[1, 2, 3]]), [100, 200, 300])
+    reference_pressure = pf.FrequencyData(np.array([[1, 2]]), [100, 200])
+    microphone_weights = np.array([0.5, 0.5, 0.5])
+    with pytest.raises(
+            ValueError, match="The last dimension of sample_pressure must "
+            "match the size of microphone_weights"):
+        sff.correlation_method(
+            sample_pressure, reference_pressure, microphone_weights)

--- a/tests/test_scattering_freefield.py
+++ b/tests/test_scattering_freefield.py
@@ -57,7 +57,7 @@ def test_correlation_fractional_scattering(s_scatter, Phi_scatter_deg):
     """
     Test analytic scattering coefficient calculation for non 0 or 1.
 
-    for the sample pressure, two plane waves are used. The scattered and the
+    For the sample pressure, two plane waves are used. The scattered and the
     specular wave. The reflection factor of both waves is calculated based on
     the scattering coefficient and the scattering angle.
     """
@@ -91,7 +91,7 @@ def test_correlation_fractional_scattering(s_scatter, Phi_scatter_deg):
 
     # Calculate the scattering coefficient with for the scattered wave
     # in other words, the reference pressure is the scattered wave (R=1)
-    # to the result will be 1-s_scatter
+    # so the result will be 1-s_scatter
     reference_pressure = plane_wave(
         1, pf.Coordinates.from_spherical_front(
             np.pi/2, Phi_scatter, 1), sampling)
@@ -100,8 +100,8 @@ def test_correlation_fractional_scattering(s_scatter, Phi_scatter_deg):
     )
     npt.assert_almost_equal(sd_scatter.freq, s_scatter, 1)
 
-    # Calculate the scattering coefficient with for 5° more then the specular
-    # wave, than the scattering coefficient should be 0
+    # Calculate the scattering coefficient for 5° more than the specular
+    # wave, then the scattering coefficient should be 0
     reference_pressure = plane_wave(
         1, pf.Coordinates.from_spherical_front(
             np.pi/2, Phi_spec+5/180*np.pi, 1), sampling)

--- a/tests/test_scattering_freefield.py
+++ b/tests/test_scattering_freefield.py
@@ -89,7 +89,7 @@ def test_correlation_fractional_scattering(s_scatter, Phi_scatter_deg):
     )
     npt.assert_almost_equal(sd_spec.freq, s_spec, 1)
 
-    # Calculate the scattering coefficient with for the scattered wave
+    # Calculate the scattering coefficient for the scattered wave
     # in other words, the reference pressure is the scattered wave (R=1)
     # so the result will be 1-s_scatter
     reference_pressure = plane_wave(

--- a/tests/test_scattering_freefield.py
+++ b/tests/test_scattering_freefield.py
@@ -112,6 +112,7 @@ def test_correlation_fractional_scattering(s_scatter, Phi_scatter_deg):
 
 
 def test_correlation_one_scattering():
+    """Two plane waves in the different directions should result in s=1."""
     sampling = pf.samplings.sph_equal_area(5000)
     sampling.weights = pf.samplings.calculate_sph_voronoi_weights(sampling)
     sampling = sampling[sampling.z>0]

--- a/tests/test_scattering_freefield.py
+++ b/tests/test_scattering_freefield.py
@@ -29,7 +29,7 @@ def plane_wave(amplitude, direction, sampling):
     f = 5000
     c = 343
     x = sampling
-    direction.cartesian = direction.cartesian/direction.radius
+    direction.radius = 1
     dot_product = direction.x*x.x+direction.y*x.y+direction.z*x.z
     dot_product = dot_product[..., np.newaxis]
     f = np.atleast_1d(f)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes  #12 

### Changes proposed in this pull request:

- introduce correlation method after mommertz, in other words, calcualte scattering coefficient from freefield measurements depending on the incident direciton

requires  #32 
